### PR TITLE
Prevent serverkit from installing Atom packages to fix CI

### DIFF
--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -13,8 +13,8 @@ resources:
   <%- end -%>
 
   <%- atom_package_names.each do |atom_package_name| -%>
-  - type: atom_package
-    name: <%= atom_package_name %>
+  # - type: atom_package
+  #   name: <%= atom_package_name %>
   <%- end -%>
 
   <%- vscode_package_names.each do |vscode_package_name| -%>


### PR DESCRIPTION
## Issue

Installing Atom packages stop CI, so comment it out.

![image](https://user-images.githubusercontent.com/803398/75082726-677dc480-5558-11ea-9957-d4f1080fad07.png)


## Related

#107