### PR TITLE
Fix CI build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem "serverkit"
 gem "serverkit-atom"
 gem "serverkit-defaults"
-gem "serverkit-homebrew"
+gem "serverkit-homebrew", github: 'toshimaru/serverkit-homebrew'
 gem "serverkit-rbenv"
 gem "serverkit-vscode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/toshimaru/serverkit-homebrew.git
+  revision: e79f44a9450b6e16200c3460b31fe43fb5a75f26
+  specs:
+    serverkit-homebrew (0.0.5)
+      serverkit
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -36,8 +43,6 @@ GEM
     serverkit-defaults (0.0.3)
       plist
       serverkit
-    serverkit-homebrew (0.0.5)
-      serverkit
     serverkit-rbenv (0.3.3)
       serverkit (>= 0.6.2)
       specinfra (>= 2.31.1)
@@ -63,6 +68,9 @@ DEPENDENCIES
   serverkit
   serverkit-atom
   serverkit-defaults
-  serverkit-homebrew
+  serverkit-homebrew!
   serverkit-rbenv
   serverkit-vscode
+
+BUNDLED WITH
+   2.1.4

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -48,11 +48,6 @@ homebrew_package_names:
 - watch
 - wget
 - zsh
-# - tmux
-# NOTE: Use `docker` Desktop App (installed by cask)
-# - docker
-# - docker-compose
-# - docker-machine
 
 homebrew_cask_package_names:
 - atom

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -97,6 +97,7 @@ vscode_package_names:
 - eamodio.gitlens
 - Equinusocio.vsc-material-theme
 - GitHub.vscode-pull-request-github
+- golang.go
 - mechatroner.rainbow-csv
 - misogi.ruby-rubocop
 - ms-azuretools.vscode-docker
@@ -106,11 +107,11 @@ vscode_package_names:
 - ms-vscode-remote.remote-wsl
 - ms-vscode-remote.vscode-remote-extensionpack
 - ms-vscode.atom-keybindings
-- golang.go
 - ms-vsliveshare.vsliveshare
 - rebornix.ruby
 - robert.ruby-snippet
 - sensourceinc.vscode-sql-beautify
+- sporto.rails-go-to-spec
 - syler.sass-indented
 - toshimaru.hybrid-next-plus
 - wraith13.open-in-github-desktop

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -1,5 +1,4 @@
 atom_package_names:
-- atom-alignment
 - autocomplete-emojis
 - autocomplete-paths
 - blame
@@ -7,17 +6,16 @@ atom_package_names:
 - expand-selection-to-quotes
 - git-plus
 - go-plus
-- highlight-line
 - hybrid-next-syntax
 - language-rspec
 - linter
 - linter-eslint
 - linter-rubocop
+- markdown-writer
 - open-in-github-app
-- platformio-ide-terminal
-- project-manager
 - sort-lines
 - toggle-quotes
+- vim-mode-plus
 
 homebrew_package_names:
 - bash

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -108,7 +108,6 @@ vscode_package_names:
 - ms-vscode-remote.remote-containers
 - ms-vscode-remote.remote-ssh
 - ms-vscode-remote.remote-ssh-edit
-- ms-vscode-remote.remote-ssh-explorer
 - ms-vscode-remote.remote-wsl
 - ms-vscode-remote.vscode-remote-extensionpack
 - ms-vscode.atom-keybindings


### PR DESCRIPTION
## Description

Fix build with  forked erverkit-homebrew.

## Atom

- remove alignment, highlight-line, ide-terminal, project-manager
- Add markdown-writer, vim-mode-plus

## VScode

- remove remote-ssh-explorer
- Add rails-go-to-spec