### PR TITLE
Add `macOS-12` build with Ruby 2.7 / Add mas package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: macOS-11
+    runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2
     - name: brew install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,19 @@ name: Setup
 on: [push]
 
 jobs:
-  build:
+  macOS-11-build:
+    runs-on: macOS-11
+    steps:
+    - uses: actions/checkout@v2
+    - name: brew install
+      run: brew bundle
+    - name: bundle install & serverkit apply
+      run: ./serverkit-setup.bash
+    - name: serverkit check
+      run: |
+        # just check, ignore exit status
+        bundle exec serverkit check serverkit.yml.erb --variables=serverkit-variables.yml || exit 0
+  macOS-12-build:
     runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
     - name: brew install
       run: brew bundle
     - name: bundle install & serverkit apply

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: brew install
       run: brew bundle
-    - name: bundle install
-      run: bundle install --jobs 4 --retry 3
-    - name: serverkit apply
-      run: |
-        bundle exec serverkit apply serverkit.yml.erb --variables=serverkit-variables.yml
+    - name: bundle install & serverkit apply
+      run: ./serverkit-setup.bash
     - name: serverkit check
       run: |
         # just check, ignore exit status

--- a/.rbenv/default-gems
+++ b/.rbenv/default-gems
@@ -1,4 +1,4 @@
 # cp .rbenv/default-gems $(rbenv root)/
 bundler
 pry
-rbenv-rehash
+bundled_gems

--- a/Brewfile
+++ b/Brewfile
@@ -13,3 +13,5 @@ cask "enpass"
 cask "iterm2"
 cask "sublime-text"
 cask "visual-studio-code"
+
+mas "Magnet", id: 441258766

--- a/Brewfile
+++ b/Brewfile
@@ -14,4 +14,5 @@ cask "iterm2"
 cask "sublime-text"
 cask "visual-studio-code"
 
-mas "Magnet", id: 441258766
+# Require Mac App Store sign in.
+# mas "Magnet", id: 441258766

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -6,5 +6,5 @@ if [ "$?" -ne 0 ]; then
   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-bundle install --path vendor/bundle
+bundle install --path vendor/bundle --jobs 4 --retry 3
 bundle exec serverkit apply serverkit.yml.erb --variables=serverkit-variables.yml

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -34,6 +34,7 @@ homebrew_cask_package_names:
 - alfred
 - chromedriver
 - dash
+- deckset
 - discord
 - docker
 - dropbox


### PR DESCRIPTION
## Changes

- Add [mas](https://github.com/mas-cli/mas) package
- Add macOS-12 build in addition to macOS-11 build
- Use bash script to run `bundle install` and `serverkit apply`