### PR TITLE
Update setup script for the latest macOS

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -77,5 +77,3 @@ alias vgrep='grep -v --color'
 # eval "$(rbenv init -)"
 
 export EDITOR=vim
-# export GOPATH=$HOME
-# PATH=$PATH:$GOPATH/bin

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,8 +1,18 @@
 [user]
   name = toshimaru
   email = me@toshimaru.net
-[color]
-  ui = auto
+[core]
+  excludesfile = ~/.global_ignore
+  autocrlf = input
+  editor = vim
+[rebase]
+  autosquash = true
+  autostash = true
+  abbreviateCommands = true
+[init]
+  defaultBranch = main
+[ghq]
+  root = ~/src
 [alias]
   fetch-pulls = fetch origin +refs/pull/*:refs/remotes/pull/*
   st = status -s -b
@@ -35,7 +45,6 @@
   spush = svn dcommit
   spull = svn rebase
   sfetch = svn fetch
-  k = !gitk
   pick = cherry-pick
   wip = commit --allow-empty -m '[ci skip] WIP'
   # require peco (https://github.com/peco/peco)
@@ -48,17 +57,10 @@
   ci = ci-status -v
   open = browse
   open-issue = !hub browse -- pull/${1}
-  issues = browse -- issues
-  myissues = issue -a toshimaru
-  prs = browse -- pulls
+  open-issues = browse -- issues
+  open-prs = browse -- pulls
+  list-myissues = issue -a toshimaru
+  list-pr = pr list
   pro = !hub browse -- pull/$(git branch --show-current)
-  prl = pr list
   # require GitHub Desktop App
   app = !github .
-[ghq]
-  root = ~/src
-[rebase]
-  autosquash = true
-  autostash = true
-[core]
-  autocrlf = input

--- a/.gitconfig
+++ b/.gitconfig
@@ -3,11 +3,6 @@
   email = me@toshimaru.net
 [color]
   ui = auto
-[color "diff"]
-  meta = yellow bold
-  frag = magenta bold
-  old = red bold
-  new = green bold
 [alias]
   fetch-pulls = fetch origin +refs/pull/*:refs/remotes/pull/*
   st = status -s -b

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,7 @@ jobs:
     runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.6'
-    - name: brew install
-      run: brew bundle
-    - name: bundle install & serverkit apply
+    - name: brew bundle & bundle install & serverkit apply
       run: ./serverkit-setup.bash
     - name: serverkit check
       run: |
@@ -22,12 +17,7 @@ jobs:
     runs-on: macOS-12
     steps:
     - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7'
-    - name: brew install
-      run: brew bundle
-    - name: bundle install & serverkit apply
+    - name: brew bundle & bundle install & serverkit apply
       run: ./serverkit-setup.bash
     - name: serverkit check
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
     - name: brew install
       run: brew bundle
     - name: bundle install & serverkit apply

--- a/.global_ignore
+++ b/.global_ignore
@@ -1,10 +1,9 @@
-##
-# global_ignore file.
-# ref. https://github.com/github/gitignore
+# Git global_ignore file.
 #
-# Run the command and apply rules:
-#     git config --global core.excludesfile ~/.global_ignore
-##
+# Run the command to apply rules:
+#     $ git config --global core.excludesfile ~/.global_ignore
+#
+# ref. https://github.com/github/gitignore
 
 
 ### OSX ###

--- a/.zshrc
+++ b/.zshrc
@@ -27,8 +27,6 @@ function peco-checkout-pull-request() {
     fi
     zle clear-screen
 }
-zle -N peco-checkout-pull-request
-bindkey '^B' peco-checkout-pull-request
 
 function peco-view-pull-request() {
     local selected_pr_id=$(gh pr list | peco | cut -f 1)

--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,7 @@ brew "git"
 brew "iproute2mac"
 brew "pstree"
 brew "ripgrep"
+brew "svn"
 brew "tree"
 brew "watch"
 brew "wget"
@@ -12,7 +13,9 @@ cask "docker"
 cask "enpass"
 cask "iterm2"
 cask "sublime-text"
-cask "visual-studio-code"
+
+tap "homebrew/cask-fonts"
+cask "font-dejavu-sans-mono-for-powerline"
 
 # Require Mac App Store sign in.
 # mas "Magnet", id: 441258766

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,7 @@
 brew "git"
 brew "iproute2mac"
 brew "pstree"
+brew "rbenv"
 brew "ripgrep"
 brew "svn"
 brew "tree"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     unix-crypt (1.3.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
 
 DEPENDENCIES
@@ -62,4 +63,4 @@ DEPENDENCIES
   serverkit-vscode
 
 BUNDLED WITH
-   2.3.13
+   2.3.7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 ![Setup](https://github.com/toshimaru/dotfiles/workflows/Setup/badge.svg)
 
-# dotfiles 
+# dotfiles
 
 My dotfiles.
+
+## Prerequisites
+
+- macOS v11 or more
+- Apple M1 / Intel
+- Ruby v2.7
 
 ## Powered By
 

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -6,5 +6,10 @@ if [ "$?" -ne 0 ]; then
   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
+# Use Ruby 2.7.x
+brew bundle
+eval "$(rbenv init -)"
+rbenv install 2.7.6 && rbenv local 2.7.6
+
 bundle install --path vendor/bundle --jobs 4 --retry 3
 bundle exec serverkit apply serverkit.yml.erb --variables=serverkit-variables.yml

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -48,17 +48,12 @@ resources:
     notify:
       - restart_dock
   - type: defaults
-    domain: com.apple.menuextra.battery
-    key: ShowPercent
-    value: 1
-    notify:
-      - restart_systemuiserver
-  - type: defaults
     domain: com.apple.screensaver
     key: askForPasswordDelay
     value: 0
   - type: defaults
-    key: com.apple.mouse.tapBehavior
+    domain: com.apple.AppleMultitouchTrackpad
+    key: Clicking
     value: 1
 
 handlers:

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -39,8 +39,11 @@ resources:
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.vimrc
     source: /Users/<%= ENV["USER"] %>/.vimrc
   - type: symlink
+    destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.global_ignore
+    source: /Users/<%= ENV["USER"] %>/.global_ignore
+  - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.rbenv/default-gems
-    source: /Users/<%= ENV["USER"] %>/.rbenv/default-gems  
+    source: /Users/<%= ENV["USER"] %>/.rbenv/default-gems
 
   - type: defaults
     domain: com.apple.dock

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -1,7 +1,4 @@
 resources:
-  - type: command
-    script: brew update
-
   <%- homebrew_package_names.each do |homebrew_package_name| -%>
   - type: homebrew_package
     name: <%= homebrew_package_name %>
@@ -26,11 +23,15 @@ resources:
     script: |
       curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 
+  # Create dotfiles from cloned dotfiles repo
   - type: git
     repository: https://github.com/toshimaru/dotfiles.git
     path: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles
     status: updated
-
+  - type: command
+    script: |
+      cp /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.gitconfig \
+         /Users/<%= ENV["USER"] %>/.gitconfig
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.pryrc
     source: /Users/<%= ENV["USER"] %>/.pryrc


### PR DESCRIPTION
## Changes

- Install Ruby 2.7.x via rbenv in order to run serverkit without an error
  - serverkit doesn't work for Ruby 3.x
- Add package: svn, font-dejavu-sans-mono-for-powerline
- Remove GOPATH
  - ref. [Go Modules : Project set up without GOPATH | by Navarasu | Francium Tech](https://blog.francium.tech/go-modules-go-project-set-up-without-gopath-1ae601a4e868?gi=c04009e2e7ac)
- Modify .gitconfig
- Remove `bindkey '^B'` since it should be "back"