### PR TITLE
Remove postgresql brew package

### DIFF
--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -15,7 +15,6 @@ homebrew_package_names:
 - mysql
 - node
 - peco
-- postgresql
 - pstree
 - rbenv
 - rbenv-default-gems


### PR DESCRIPTION
Since brew requires the version to install postgresql

```
[FAIL] homebrew_package postgresql on localhost
```

To install successfully:

```console
$ brew install postgresql@15
```

postgresql is not used recently, so I remove it.