### PR TITLE
fix: Stop Installing chromedriver

### DIFF
--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -32,7 +32,6 @@ homebrew_package_names:
 
 homebrew_cask_package_names:
 - brave-browser
-- chromedriver
 - cloudflare-warp
 - dash
 - deckset
@@ -64,6 +63,7 @@ homebrew_cask_package_names:
 - wireshark
 # - amazon-music
 # - choosy
+# - chromedriver
 # - google-cloud-sdk
 # - karabiner-elements
 # - utm


### PR DESCRIPTION
To avoid the following error:

```
==> Downloading https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/mac-x64/chromedriver-mac-x64.zip
Warning: macOS's Gatekeeper has been disabled for this Cask
==> Installing Cask chromedriver
==> Purging files for version 11[5](https://github.com/toshimaru/dotfiles/actions/runs/5989276598/job/16245295123#step:2:6).0.5790.170 of Cask chromedriver
Error: It seems there is already a Binary at '/usr/local/bin/chromedriver'.
Error: Process completed with exit code 1.
```
