### PR TITLE
ci: Add macOS-13 to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   setup:
     strategy:
       matrix:
-        os: [macOS-11, macOS-12, macOS-13]
+        os: [macOS-12, macOS-13]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,5 @@ jobs:
         run: ./serverkit-setup.bash
       - name: serverkit check
         run: bundle exec serverkit check serverkit.yml.erb --variables=serverkit-variables.yml
+        # macOS-13 is still beta, so we ignore the failure.
+        continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,3 @@ jobs:
         run: ./serverkit-setup.bash
       - name: serverkit check
         run: bundle exec serverkit check serverkit.yml.erb --variables=serverkit-variables.yml
-        # macOS-13 is still beta, so we ignore the failure.
-        continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   setup:
     strategy:
       matrix:
-        os: [macOS-11, macOS-12]
+        os: [macOS-11, macOS-12, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
       matrix:
         os: [macOS-11, macOS-12, macOS-13]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: brew bundle & bundle install & serverkit apply


### PR DESCRIPTION
## Changes

- deps: Drop macOS-11, add macos-13 instead
- chore: Set `timeout-minutes`
- Set `continue-on-error: true`

## Reference

- [GitHub Actions: macOS 13 is now available - The GitHub Blog](https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/)
- [runner-images/images/macos/macos-13-Readme.md at main · actions/runner-images](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)