### PR TITLE
fix: Update VSCode extension names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -71,15 +71,15 @@ homebrew_cask_package_names:
 
 vscode_package_names:
 - aaron-bond.better-comments
-- alefragnani.Bookmarks
+- alefragnani.bookmarks
 - arcticicestudio.nord-visual-studio-code
 - bierner.emojisense
-- BriteSnow.vscode-toggle-quotes
+- britesnow.vscode-toggle-quotes
 - christian-kohler.path-intellisense
 - chunsen.bracket-select
 - eamodio.gitlens
-- Equinusocio.vsc-material-theme
-- GitHub.vscode-pull-request-github
+- equinusocio.vsc-material-theme
+- github.vscode-pull-request-github
 - golang.go
 - mechatroner.rainbow-csv
 - ms-azuretools.vscode-docker


### PR DESCRIPTION
## Fix VSCode extension names

> The name of the extension - should be all lowercase with no spaces.

https://code.visualstudio.com/api/references/extension-manifest