### PR TITLE
fix: Remove `tap 'homebrew/cask-fonts'`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,15 +10,13 @@ brew 'wget'
 
 cask 'docker'
 cask 'enpass'
-cask 'iterm2'
-cask 'sublime-text'
-
-tap 'homebrew/cask-fonts'
 cask 'font-cica'
 cask 'font-dejavu'
 cask 'font-fira-code'
 cask 'font-jetbrains-mono'
 cask 'font-monaspace'
+cask 'iterm2'
+cask 'sublime-text'
 
 # Require `mas` and sign in to App Store.
 # mas 'Gapplin', id: 768053424


### PR DESCRIPTION
Fix the following error:

```
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```