### PR TITLE
Remove serverkit-defaults gem from `Gemfile`

### DIFF
--- a/.gvimrc
+++ b/.gvimrc
@@ -1,1 +1,0 @@
-colorscheme hybrid

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "serverkit"
-gem "serverkit-defaults"
 gem "serverkit-homebrew"
 gem "serverkit-rbenv"
 gem "serverkit-vscode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.3.0)
     net-telnet (0.2.0)
-    plist (3.7.2)
     rainbow (3.1.1)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -49,9 +48,6 @@ GEM
       slop (~> 3.4)
       specinfra (>= 2.31.0)
       unix-crypt
-    serverkit-defaults (0.0.3)
-      plist
-      serverkit
     serverkit-homebrew (0.0.6)
       serverkit
     serverkit-rbenv (0.3.3)
@@ -82,7 +78,6 @@ PLATFORMS
 
 DEPENDENCIES
   serverkit
-  serverkit-defaults
   serverkit-homebrew
   serverkit-rbenv
   serverkit-vscode

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 
 # Install homebrew if it's not installed
 if ! which brew > /dev/null ; then


### PR DESCRIPTION
- Delete `.gvimrc`
  - MacVim is no longer used
- deps: Remove serverkit-defaults gem
  - see. 14e45c1
    - com.apple.dock: autohide
    - com.apple.screensaver: askpassword
    - com.apple.AppleMultitouchTrackpad: clicking
- chore: Add `-x` option to bash script