### PR TITLE
ci: Drop `macOS-13` support, Add `macOS-15` instead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   setup:
     strategy:
       matrix:
-        os: [macOS-13, macOS-14]
+        os: [macOS-14, macOS-15]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:

--- a/.rbenv/default-gems
+++ b/.rbenv/default-gems
@@ -1,5 +1,8 @@
 # cp .rbenv/default-gems $(rbenv root)/
 bundled_gems
 bundler
+rails
 rubocop
+ruby-lsp
 solargraph
+standard

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -25,7 +25,6 @@ resources:
   - type: git
     repository: https://github.com/toshimaru/dotfiles.git
     path: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles
-    status: updated
   # Setup my dotfiles
   - type: command
     check_script: test -f ~/.gitconfig

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -37,9 +37,6 @@ resources:
     script: curl https://get.volta.sh | bash
   # symlinks
   - type: symlink
-    destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.pryrc
-    source: /Users/<%= ENV["USER"] %>/.pryrc
-  - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.vimrc
     source: /Users/<%= ENV["USER"] %>/.vimrc
   - type: symlink

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -14,7 +14,7 @@ resources:
     name: <%= vscode_package_name %>
   <%- end -%>
   - type: rbenv_ruby
-    version: 3.4.1
+    version: 3.4.3
     global: true
   # Install plug.vim
   - type: command


### PR DESCRIPTION
- ci: Drop macOS-13 support, Add macOS-15 instead
- Remove `.pryrc`
  - related. d47a761
- Update `default-gems` for rbenv
- Bump installed Ruby from 3.4.1 to 3.4.3
- Remove repository status
