### PR TITLE
Introducing serverkit-mise

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -70,7 +70,4 @@ alias vgrep='grep -v --color'
 # https://starship.rs
 # eval "$(starship init bash)"
 
-# https://github.com/rbenv/rbenv
-# eval "$(rbenv init -)"
-
 export EDITOR=vim

--- a/.bashrc
+++ b/.bashrc
@@ -70,4 +70,7 @@ alias vgrep='grep -v --color'
 # https://starship.rs
 # eval "$(starship init bash)"
 
+# https://mise.jdx.dev/getting-started.html
+# eval "$(mise activate bash)"
+
 export EDITOR=vim

--- a/.zshrc
+++ b/.zshrc
@@ -21,3 +21,6 @@ bindkey '^V' peco-history-selection
 
 # https://starship.rs
 # eval "$(starship init zsh)"
+
+# https://mise.jdx.dev/getting-started.html
+# eval "$(mise activate zsh)"

--- a/Brewfile
+++ b/Brewfile
@@ -3,7 +3,6 @@
 brew 'git'
 brew 'mise'
 brew 'pstree'
-brew 'rbenv'
 brew 'ripgrep'
 brew 'tree'
 brew 'watch'

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 # Run `brew bundle` to install the following packages.
 
 brew 'git'
+brew 'mise'
 brew 'pstree'
 brew 'rbenv'
 brew 'ripgrep'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "serverkit"
 gem "serverkit-homebrew"
+gem "serverkit-mise"
 gem "serverkit-rbenv"
 gem "serverkit-vscode"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "serverkit"
-gem "serverkit-homebrew"
-gem "serverkit-mise"
-gem "serverkit-rbenv"
-gem "serverkit-vscode"
+gem 'serverkit'
+gem 'serverkit-homebrew'
+gem 'serverkit-mise'
+gem 'serverkit-vscode'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,8 @@ GEM
     uri (1.0.3)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
   arm64-darwin-24
-  x86_64-darwin-21
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   serverkit
@@ -83,4 +79,4 @@ DEPENDENCIES
   serverkit-vscode
 
 BUNDLED WITH
-   2.3.26
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,9 +52,6 @@ GEM
       serverkit
     serverkit-mise (0.0.1)
       serverkit
-    serverkit-rbenv (0.3.3)
-      serverkit (>= 0.6.2)
-      specinfra (>= 2.31.1)
     serverkit-vscode (0.1.1)
       serverkit
     sfl (2.3)
@@ -78,7 +75,6 @@ DEPENDENCIES
   serverkit
   serverkit-homebrew
   serverkit-mise
-  serverkit-rbenv
   serverkit-vscode
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       unix-crypt
     serverkit-homebrew (0.0.6)
       serverkit
+    serverkit-mise (0.0.1)
+      serverkit
     serverkit-rbenv (0.3.3)
       serverkit (>= 0.6.2)
       specinfra (>= 2.31.1)
@@ -75,6 +77,7 @@ PLATFORMS
 DEPENDENCIES
   serverkit
   serverkit-homebrew
+  serverkit-mise
   serverkit-rbenv
   serverkit-vscode
 

--- a/oh-my-zsh_plugins
+++ b/oh-my-zsh_plugins
@@ -8,7 +8,6 @@ plugins=(
     gh
     git
     rails
-    rbenv
     z
     zsh-syntax-highlighting # https://github.com/zsh-users/zsh-syntax-highlighting
 )

--- a/serverkit-variables.yml
+++ b/serverkit-variables.yml
@@ -15,8 +15,6 @@ homebrew_package_names:
   - mysql
   - peco
   - pstree
-  - rbenv
-  - rbenv-default-gems
   - redis
   - ripgrep
   - starship

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -13,10 +13,6 @@ resources:
   - type: vscode_package
     name: <%= vscode_package_name %>
   <%- end -%>
-  - type: mise_use
-    name: ruby
-  - type: mise_use
-    name: go
   # Install plug.vim
   - type: command
     check_script: test -f ~/.vim/autoload/plug.vim
@@ -46,3 +42,8 @@ resources:
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.rbenv/default-gems
     source: /Users/<%= ENV["USER"] %>/.default-gems
+  # Install tools via mise
+  - type: mise_use
+    name: ruby
+  - type: mise_use
+    name: go

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -31,10 +31,6 @@ resources:
     check_script: test -f ~/.gitconfig
     script: |
       cp -n /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.gitconfig ~/.gitconfig
-  # Use volta to manage node tools
-  - type: command
-    check_script: test -d ~/.volta
-    script: curl https://get.volta.sh | bash
   # symlinks
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.vimrc

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -13,9 +13,6 @@ resources:
   - type: vscode_package
     name: <%= vscode_package_name %>
   <%- end -%>
-  - type: rbenv_ruby
-    version: 3.4.3
-    global: true
   - type: mise_use
     name: ruby
   - type: mise_use

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -16,6 +16,10 @@ resources:
   - type: rbenv_ruby
     version: 3.4.3
     global: true
+  - type: mise_use
+    name: ruby
+  - type: mise_use
+    name: go
   # Install plug.vim
   - type: command
     check_script: test -f ~/.vim/autoload/plug.vim

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -49,4 +49,4 @@ resources:
     source: /Users/<%= ENV["USER"] %>/.config/git/ignore
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.rbenv/default-gems
-    source: /Users/<%= ENV["USER"] %>/.rbenv/default-gems
+    source: /Users/<%= ENV["USER"] %>/.default-gems


### PR DESCRIPTION
Intoducing [serverkit-mise](https://github.com/serverkit/serverkit-mise), removing volta, serverkit-rbenv.

## Changes

- Update Gemfile.lock
- deps: Add serverkit-mise plugin
- Install ruby@latest and go@latest via mise
- deps: Remove serverkit-rbenv
- Create `$HOME/.default-gems`
- deps: Remove volta
- Run `mise activate` in rc files
- chore: Install Ruby after creating `.default-gems`

## TODOs

- [ ] Install oh-my-zsh
- [ ] Update vscode plugin
- [ ] Update brew packages

To be addressed in a follow-up PR.
