### PR TITLE
Fix setup script (2025-04)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -8,8 +8,6 @@ brew 'tree'
 brew 'watch'
 brew 'wget'
 
-cask 'docker'
-cask 'enpass'
 cask 'font-cica'
 cask 'font-dejavu'
 cask 'font-fira-code'
@@ -17,7 +15,6 @@ cask 'font-jetbrains-mono'
 cask 'font-monaspace'
 cask 'font-moralerspace'
 cask 'iterm2'
-cask 'sublime-text'
 
 # Require `mas` and sign in to App Store.
 # mas 'Gapplin', id: 768053424

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -5,6 +5,7 @@ if ! which brew > /dev/null ; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 # Install basic tools from Brewfile
+eval "$(/opt/homebrew/bin/brew shellenv)"
 brew update && brew bundle
 
 bundle install --path vendor/bundle --jobs 4 --retry 3


### PR DESCRIPTION
## docker/enpass require password

```
Installing docker
Password:
```

```
Installing enpass
Password:
==> Downloading https://dl.enpass.io/stable/mac/package/6.11.10.1951/Enpass.pkg
==> Installing Cask enpass
==> Running installer for enpass with sudo; the password may be necessary.
installer: This package requires Rosetta 2 to be installed.
                Please install Rosetta 2 and then try again.
                    `sudo softwareupdate --install-rosetta`
```

## brew PATH setup

```
==> Next steps:
- Run these commands in your terminal to add Homebrew to your PATH:
    echo >> /Users/toshimaru/.zprofile
    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/toshimaru/.zprofile
    eval "$(/opt/homebrew/bin/brew shellenv)"
- Run brew help to get started
- Further documentation:
    https://docs.brew.sh/
```