### PR TITLE
Add `.zprofile` for brew command / Add vim alias

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -52,6 +52,7 @@ alias g='git'
 alias o='open'
 alias p='peco'
 alias tailf='tail -f'
+alias v='vim'
 # ls
 alias l='la'
 alias la='ls -lA'

--- a/.zprofile
+++ b/.zprofile
@@ -1,3 +1,2 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
-eval "$(starship init zsh)"
 eval "$(mise activate zsh)"

--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,3 @@
+eval "$(/opt/homebrew/bin/brew shellenv)"
+eval "$(starship init zsh)"
+eval "$(mise activate zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -18,9 +18,3 @@ function peco-history-selection() {
 }
 zle -N peco-history-selection
 bindkey '^V' peco-history-selection
-
-# https://starship.rs
-# eval "$(starship init zsh)"
-
-# https://mise.jdx.dev/getting-started.html
-# eval "$(mise activate zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -18,3 +18,6 @@ function peco-history-selection() {
 }
 zle -N peco-history-selection
 bindkey '^V' peco-history-selection
+
+# Load starship after initializing oh-my-zsh
+# eval "$(starship init zsh)"

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -12,4 +12,7 @@ brew update && brew bundle
 mise use --global ruby
 eval "$(mise activate bash)"
 bundle install --path vendor/bundle --jobs 4 --retry 3
+
+# Install rosetta to fix "This package requires Rosetta 2 to be installed."
+sudo softwareupdate --install-rosetta
 bundle exec serverkit apply serverkit.yml.erb --variables=variables.yml

--- a/serverkit-setup.bash
+++ b/serverkit-setup.bash
@@ -14,5 +14,7 @@ eval "$(mise activate bash)"
 bundle install --path vendor/bundle --jobs 4 --retry 3
 
 # Install rosetta to fix "This package requires Rosetta 2 to be installed."
-sudo softwareupdate --install-rosetta
+if ! pgrep -q oahd; then
+  sudo softwareupdate --install-rosetta --agree-to-license
+fi
 bundle exec serverkit apply serverkit.yml.erb --variables=variables.yml

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -47,6 +47,9 @@ resources:
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.default-gems
     source: /Users/<%= ENV["USER"] %>/.default-gems
+  - type: symlink
+    destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.zprofile
+    source: /Users/<%= ENV["USER"] %>/.zprofile
   # Install tools via mise
   - type: mise_use
     name: ruby

--- a/variables.yml
+++ b/variables.yml
@@ -38,6 +38,7 @@ homebrew_package_names:
 homebrew_cask_package_names:
   - bartender
   - brave-browser
+  - chatgpt
   - choosy
   - claude
   - cleanshot

--- a/variables.yml
+++ b/variables.yml
@@ -36,7 +36,6 @@ homebrew_package_names:
   - zsh
 
 homebrew_cask_package_names:
-  - arc
   - bartender
   - brave-browser
   - choosy


### PR DESCRIPTION
This pull request includes several updates to configuration files and scripts to enhance development setup and streamline workflows. Key changes include adding new aliases, improving environment initialization, updating package installation scripts, and modifying symbolic link configurations.

### Shell Configuration Updates:
* [`.bashrc`](diffhunk://#diff-b7cf3e96e1f74fc148d130e98db1c65c7b8eb4f5b668668fa71f26768796a5b0R55): Added an alias for `vim` to simplify command usage.
* [`.zprofile`](diffhunk://#diff-4caefeea97088d13035f1f95017dba8283d1e4b33a8bce65881e926f1eb91beaR1-R2): Added commands to initialize Homebrew and activate `mise` for the zsh shell.
* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L22-L26): Updated comments to clarify the loading sequence of `starship` and removed redundant `mise` activation command.

### Script Enhancements:
* [`serverkit-setup.bash`](diffhunk://#diff-22c3942cd2cc7adf10e1b32f5094eddb71cc4b28f3dee0fa78a0912548734213R15-R19): Added a check to install Rosetta 2 if not already installed, addressing compatibility issues with certain packages.

### Configuration File Modifications:
* [`serverkit.yml.erb`](diffhunk://#diff-f7b304347d0bb70ebcd28b2451cc3a1a04df5f5cc0b17b040fa4a8ef8c7f7198R50-R52): Added a new symbolic link resource for `.zprofile` to ensure proper configuration management.
* [`variables.yml`](diffhunk://#diff-6026bd27cefffc01295edd8430f545994aaecdc2bb96af0f0b18f7fa0b00a8c5L39-R41): Updated the list of Homebrew cask packages to include `chatgpt` and removed `arc`.