### PR TITLE
Update macOS prerequisite wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ My dotfiles.
 
 ## Prerequisites
 
-- macOS v14 or more
+- macOS v14 or later
 - Apple Silicon Mac
 - Ruby v2.7 or more
 


### PR DESCRIPTION
## Summary
- clarify macOS version requirement in README

## Testing
- `grep -n "macOS v14" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6845471a2f54832b81fa37daa045d2d5