### PR TITLE
Fix oh-my-zsh install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ My dotfiles.
 
 ## Prerequisites
 
-- macOS v14 or more
+- macOS v14 or later
 - Apple Silicon Mac
 - Ruby v2.7 or more
 

--- a/oh-my-zsh_plugins
+++ b/oh-my-zsh_plugins
@@ -1,4 +1,4 @@
-# To install oh-my-zsh, see https://github.com/robbyrussell/oh-my-zsh
+# To install oh-my-zsh, see https://github.com/ohmyzsh/ohmyzsh
 
 # oh-my-zsh plugins. Change as needed.
 plugins=(


### PR DESCRIPTION
## Summary
- update oh-my-zsh install link in `oh-my-zsh_plugins`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684547f3f830832b9b1796a9c2cc318e