### PR TITLE
Update Wireshark cask to wireshark-app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: brew bundle & bundle install & serverkit apply
         run: ./serverkit-setup.bash
+        continue-on-error: true
+      - run: mise use --global yarn@latest
       - name: serverkit check
         run: bundle install && bundle exec serverkit check serverkit.yml.erb --variables=variables.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         os: [macOS-14, macOS-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - name: brew bundle & bundle install & serverkit apply

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: brew bundle & bundle install & serverkit apply
         run: ./serverkit-setup.bash
-        continue-on-error: true
-      - run: mise use --global yarn@latest
       - name: serverkit check
         run: bundle install && bundle exec serverkit check serverkit.yml.erb --variables=variables.yml

--- a/serverkit.yml.erb
+++ b/serverkit.yml.erb
@@ -54,9 +54,11 @@ resources:
   - type: symlink
     destination: /Users/<%= ENV["USER"] %>/src/github.com/toshimaru/dotfiles/.default-gems
     source: /Users/<%= ENV["USER"] %>/.default-gems
-  - type: mise_install
-    name: yarn
-    version: "1"
+  # skip installing yarn v1
+  # see. https://github.com/mise-plugins/mise-yarn?tab=readme-ov-file#yarn-v1-missing-signatures
+  # - type: mise_install
+  #   name: yarn
+  #   version: "1"
   <%- mise_tool_names.each do |tool_name| -%>
   - type: mise_use
     name: <%= tool_name %>

--- a/variables.yml
+++ b/variables.yml
@@ -71,7 +71,7 @@ homebrew_cask_package_names:
   - sublime-text
   - typora
   - visual-studio-code
-  - wireshark
+  - wireshark-app
   - zed
   # - chromedriver
   # - google-cloud-sdk

--- a/variables.yml
+++ b/variables.yml
@@ -44,7 +44,7 @@ homebrew_cask_package_names:
   - deckset
   - devtoys
   - discord
-  - docker
+  - docker-desktop
   - dropbox
   - enpass
   - firefox


### PR DESCRIPTION
## wirewhark → wireshark-app

Replaces 'wireshark' with 'wireshark-app' in the Homebrew cask package list to ensure correct installation.

ref. https://formulae.brew.sh/cask/wireshark-app

Brew message:

```
==> Caveats
This formula only installs the command-line utilities by default.

Install Wireshark.app with Homebrew Cask:
  brew install wireshark-app
```

## docker → docker-desktop

ref. https://formulae.brew.sh/cask/docker-desktop

```console
$ brew search --cask docker
==> Casks
docker-desktop          dockey                  dozer
docker-toolbox          dockx
```

---

This pull request updates configuration files to improve tool installation reliability and ensure compatibility with recent package changes. The main changes include extending the CI workflow timeout, skipping problematic Yarn v1 installation, and updating Homebrew cask package names to match current package naming conventions.

**Continuous Integration workflow:**
* Increased the timeout for jobs in `.github/workflows/main.yml` from 20 to 25 minutes to reduce the likelihood of workflow failures due to timeouts.

**Tool installation reliability:**
* Skipped installation of Yarn v1 in `serverkit.yml.erb` due to missing signatures and related issues, referencing the official plugin documentation for context.

**Homebrew cask package updates:**
* Replaced `docker` with `docker-desktop` in the `homebrew_cask_package_names` list in `variables.yml` to reflect the current package name.
* Replaced `wireshark` with `wireshark-app` in the `homebrew_cask_package_names` list in `variables.yml` for compatibility with updated Homebrew cask naming.