### PR TITLE
chore: zsh-syntax-highlighting→zsh-autosuggestions / vsc-material-theme→vsc-vira-theme

### DIFF
--- a/.global_ignore
+++ b/.global_ignore
@@ -219,3 +219,5 @@ mise.toml
 
 ### zed ###
 .zed
+
+**/.claude/settings.local.json

--- a/oh-my-zsh_plugins
+++ b/oh-my-zsh_plugins
@@ -12,5 +12,5 @@ plugins=(
     rails
     rake
     z
-    zsh-syntax-highlighting # https://github.com/zsh-users/zsh-syntax-highlighting
+    zsh-autosuggestions # https://github.com/zsh-users/zsh-autosuggestions
 )

--- a/variables.yml
+++ b/variables.yml
@@ -91,7 +91,6 @@ vscode_package_names:
   - chunsen.bracket-select
   - denoland.vscode-deno
   - docker.docker
-  - equinusocio.vsc-material-theme
   - github.codespaces
   - github.copilot
   - github.copilot-chat
@@ -114,6 +113,7 @@ vscode_package_names:
   - syler.sass-indented
   - tamasfe.even-better-toml
   - toshimaru.hybrid-next-plus
+  - vira.vsc-vira-theme
   - vsls-contrib.gistfs
   - wraith13.open-in-github-desktop
   - yzhang.markdown-all-in-one


### PR DESCRIPTION
This pull request makes a few targeted updates to configuration files to improve development tooling and environment management. The main changes include updating ignored files, modifying Zsh plugins, and adjusting the list of recommended VS Code extensions.

Development environment configuration:

* Updated `.global_ignore` in `mise.toml` to ignore all `settings.local.json` files under any `.claude` directory, preventing local Claude settings from being tracked.

Shell plugin management:

* Replaced `zsh-syntax-highlighting` with `zsh-autosuggestions` in the `oh-my-zsh_plugins` file to provide command autosuggestions instead of syntax highlighting in Zsh.

VS Code extension recommendations:

* Removed `equinusocio.vsc-material-theme` from the `vscode_package_names` list in `variables.yml`, streamlining the set of recommended themes.
* Added `vira.vsc-vira-theme` to the `vscode_package_names` list in `variables.yml` to introduce a new recommended theme.

---

## References

- [Frequently Asked Questions | Starship](https://starship.rs/faq/)