### PR TITLE
Remove invalid Homebrew package

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -25,7 +25,6 @@ homebrew_package_names:
   - starship
   - tig
   - toshimaru/nyan/nyan
-  - toshimaru/torch/torch-cmd
   - tre-command
   - tree
   - vim


### PR DESCRIPTION
### Motivation
- Remove the invalid Homebrew package entry `toshimaru/torch/torch-cmd` from `variables.yml` to prevent package lookup failures and keep the package list valid.

### Description
- Deleted the `toshimaru/torch/torch-cmd` line from `variables.yml` and committed the change.

### Testing
- Automated checks: `ruby -ryaml -e 'YAML.load_file("variables.yml")'` succeeded; `bundle exec serverkit apply --variables=variables.yml --recipe=serverkit.yml.erb --dry-run` failed due to missing `serverkit` executable; `bundle install --local` failed due to missing local gem cache; `gem install bundler -v 2.6.2` failed with network `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2acf478fc88329901a9415181d38db)